### PR TITLE
Update to org.reflections:reflection 0.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.9-RC1</version>
+      <version>0.9.10</version>
      </dependency>  
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
The method org.reflections.util.ClasspathHelper.forPackage had its return type changed from Set to Collection, causing a java.lang.NoSuchMethodError with the latest version. Using the older version causes the same in swagger-jaxrs.